### PR TITLE
return proper module value for initialization

### DIFF
--- a/pytlspsk/ssl_psk.c
+++ b/pytlspsk/ssl_psk.c
@@ -113,9 +113,15 @@ init_ssl_psk(void)
 {
     PyObject* m = Py_InitModule("_ssl_psk", Methods);
     if (m == NULL)
-        return;
+        return NULL;
 
     Error = PyErr_NewException("_ssl_psk.error", NULL, NULL);
     Py_INCREF(Error);
-    PyModule_AddObject(m, "error", Error);
+    if (PyModule_AddObject(m, "error", Error) < 0) {
+      Py_XDECREF(Error);
+      Py_CLEAR(Error);
+      Py_DECREF(m);
+      return NULL;
+    }
+    return m;
 }


### PR DESCRIPTION
As the official documentation[1] states the PyMODINIT_FUNC
should return a PyModule* instance.

[1]https://docs.python.org/3/extending/extending.html#intermezzo-errors-and-exceptions